### PR TITLE
issues/commit to be links, not spans

### DIFF
--- a/test/markdown-conversions/basic-issue-in-link.html
+++ b/test/markdown-conversions/basic-issue-in-link.html
@@ -1,0 +1,1 @@
+<a href="gitterHQ/gitter#1" rel="nofollow" target="_blank" class="link">this link should probably break/a>

--- a/test/markdown-conversions/basic-issue-in-link.markdown
+++ b/test/markdown-conversions/basic-issue-in-link.markdown
@@ -1,0 +1,1 @@
+[this link should probably break](gitterHQ/gitter#1)

--- a/test/markdown-conversions/commit-link.html
+++ b/test/markdown-conversions/commit-link.html
@@ -1,0 +1,1 @@
+<a href="https://github.com/gitterHQ/gitter/commit/0c5f68b9a0a80ebdd6b98484c305de08777fd0bd" rel="nofollow" target="_blank" class="commit" data-link-type="commit" data-commit-sha="0c5f68b9a0a80ebdd6b98484c305de08777fd0bd" data-commit-repo="gitterHQ/gitter">i should look like a commit</a>

--- a/test/markdown-conversions/commit-link.markdown
+++ b/test/markdown-conversions/commit-link.markdown
@@ -1,0 +1,1 @@
+[i should look like a commit](https://github.com/gitterHQ/gitter/commit/0c5f68b9a0a80ebdd6b98484c305de08777fd0bd)

--- a/test/markdown-conversions/issue-link.html
+++ b/test/markdown-conversions/issue-link.html
@@ -1,0 +1,1 @@
+<a href="https://github.com/gitterHQ/gitter/issues/1" rel="nofollow" target="_blank" class="issue" data-link-type="issue" data-issue="1" data-issue-repo="gitterHQ/gitter">i should be an issue link</a>

--- a/test/markdown-conversions/issue-link.markdown
+++ b/test/markdown-conversions/issue-link.markdown
@@ -1,0 +1,1 @@
+[i should be an issue link](https://github.com/gitterHQ/gitter/issues/1)


### PR DESCRIPTION
The problems that I want to solve are these:
- you cant write markdown for a link to a commit that has the text of a commit message but is also decorated like a commit. I.e you cant write the "pushed commits to github" commits in the activity feed in markdown.
- we're converting all our span issues to links on the client, which is just silly.

Id also like to turn all `@mentions` into links as well (wdyt @lerouxb?)
Id like to also add a `githubContext` option to the processor, so that we stop decorating `#1` as an issue if you are not in a repo room or sub channel. That make our issue decoration much more reliable.

opinions please @suprememoocow @lerouxb 

(btw there are examples committed as tests)
