### PR TITLE
Isolate reference links between messages

### DIFF
--- a/lib/process-chat.js
+++ b/lib/process-chat.js
@@ -248,6 +248,10 @@ module.exports = exports = function processChat(text) {
   if(text) {
     text = "" + text; // Force to string
     var renderer = getRenderer(renderContext);
+    // Reset any references, see https://github.com/gitterHQ/gitter/issues/1041
+    lexer.tokens = [];
+    lexer.tokens.links = {};
+
     var tokens = lexer.lex(text);
     var parser = new marked.Parser(_.extend({ renderer: renderer }, options));
     html = parser.parse(tokens);

--- a/test/process-chat-test.js
+++ b/test/process-chat-test.js
@@ -26,4 +26,14 @@ describe('process-chat', function() {
 
   });
 
+  it('should isolate link references between messages', function() {
+    var inputMd1 = '[Community for developers to chat][1]\n\n[1]: https://gitter.im/';
+    var inputMd2 = 'arr[1]';
+    var html1 = processChat(inputMd1).html;
+    assert.equal(html1.trim(), '<a href="https://gitter.im/" rel="nofollow" target="_blank" class="link">Community for developers to chat</a>');
+    var html2 = processChat(inputMd2).html;
+    assert.equal(html2.trim(), 'arr[1]');
+  });
+
+
 });


### PR DESCRIPTION
Fixes https://github.com/gitterHQ/gitter/issues/1041

Isolate reference links between messages.

Now when these two messages are sent. The second doesn't pick up the reference from the first.

```
[Community for developers to chat][1]

[1]: http://gitter.im
```

```
arr[1]
```

---

I wish `marked` had a more programmatic defined way to reset reference links. With their [`InlineLexer`](https://github.com/chjj/marked/blob/8f9d0b72f5606ed32057049f387161dd41c36ade/lib/marked.js#L520) you can pass them directly but it isn't the case with the normal [`Lexer`](https://github.com/chjj/marked/blob/8f9d0b72f5606ed32057049f387161dd41c36ade/lib/marked.js#L104)
